### PR TITLE
Added linking to libm

### DIFF
--- a/export.go
+++ b/export.go
@@ -6,7 +6,7 @@ package context
 // See: http://golang.org/cmd/cgo/#hdr-C_references_to_Go
 
 // #cgo pkg-config: --cflags --libs libsass
-// #cgo LDFLAGS: -lsass -lstdc++ -ldl
+// #cgo LDFLAGS: -lsass -lstdc++ -ldl -lm
 // #include "sass_context.h"
 //
 import "C"


### PR DESCRIPTION
I had to add -lm to link against libm and fix following error:

    /usr/bin/ld: /home/mamaar/Development/libsass/lib/libsass.a(eval.o): undefined reference to symbol 'fmod@@GLIBC_2.2.5'
    /lib/x86_64-linux-gnu/libm.so.6: error adding symbols: DSO missing from command line
    collect2: error: ld returned 1 exit status