### PR TITLE
Threadsafe

### DIFF
--- a/context.go
+++ b/context.go
@@ -99,7 +99,7 @@ func (ctx *Context) Init(goopts libs.SassOptions) libs.SassOptions {
 
 	Mixins(ctx)
 	ctx.Headers.Bind(goopts)
-	ctx.SetImporters(goopts)
+	ctx.Imports.Bind(goopts)
 	ctx.SetFunc(goopts)
 	libs.SetIncludePaths(goopts, ctx.IncludePaths)
 	libs.SassOptionSetPrecision(goopts, ctx.Precision)

--- a/context.go
+++ b/context.go
@@ -50,7 +50,7 @@ type Context struct {
 	// Headers are a map of strings to start any Sass project with. Any
 	// header listed here will be present before any other Sass code is
 	// compiled.
-	Headers Headers
+	Headers *Headers
 
 	// ResolvedImports is the list of files libsass used to compile this
 	// Sass sheet.
@@ -84,7 +84,9 @@ func init() {
 }
 
 func NewContext() *Context {
-	c := Context{}
+	c := Context{
+		Headers: NewHeaders(),
+	}
 
 	return &c
 }
@@ -96,8 +98,7 @@ func (ctx *Context) Init(goopts libs.SassOptions) libs.SassOptions {
 	}
 
 	Mixins(ctx)
-
-	ctx.SetHeaders(goopts)
+	ctx.Headers.Bind(goopts)
 	ctx.SetImporters(goopts)
 	ctx.SetFunc(goopts)
 	libs.SetIncludePaths(goopts, ctx.IncludePaths)

--- a/context.go
+++ b/context.go
@@ -98,7 +98,6 @@ func (ctx *Context) Init(goopts libs.SassOptions) libs.SassOptions {
 		ctx.Precision = 5
 	}
 
-	Mixins(ctx)
 	ctx.Headers.Bind(goopts)
 	ctx.Imports.Bind(goopts)
 	ctx.Funcs.Bind(goopts)

--- a/context.go
+++ b/context.go
@@ -62,7 +62,6 @@ type Context struct {
 
 	// Safe place to store memory allocations for C
 	entries *[]libs.ImportEntry
-	cookies *[]libs.Cookie
 }
 
 // Constants/enums for the output style.

--- a/context.go
+++ b/context.go
@@ -59,6 +59,10 @@ type Context struct {
 	// Attach additional data to a context for use by custom
 	// handlers/mixins
 	Payload interface{}
+
+	// Safe place to store memory allocations for C
+	entries *[]libs.ImportEntry
+	cookies *[]libs.Cookie
 }
 
 // Constants/enums for the output style.

--- a/context.go
+++ b/context.go
@@ -39,14 +39,14 @@ type Context struct {
 
 	in  io.Reader
 	out io.Writer
-	// Place to keep cookies, so Go doesn't garbage collect them before C
-	// is done with them
-	Cookies []Cookie
 
+	// Funcs is a slice of Sass function handlers. Registry these globally
+	// by calling RegisterHandler
+	Funcs *Funcs
 	// Imports is a map of overridden imports. When Sass attempts to
 	// import a path matching on in this map, it will include the import
 	// found in the map before looking for a file on the system.
-	Imports Imports
+	Imports *Imports
 	// Headers are a map of strings to start any Sass project with. Any
 	// header listed here will be present before any other Sass code is
 	// compiled.
@@ -84,11 +84,12 @@ func init() {
 }
 
 func NewContext() *Context {
-	c := Context{
+	c := &Context{
 		Headers: NewHeaders(),
+		Imports: NewImports(),
 	}
-
-	return &c
+	c.Funcs = NewFuncs(c)
+	return c
 }
 
 // Init validates options in the struct and returns a Sass Options.
@@ -100,7 +101,7 @@ func (ctx *Context) Init(goopts libs.SassOptions) libs.SassOptions {
 	Mixins(ctx)
 	ctx.Headers.Bind(goopts)
 	ctx.Imports.Bind(goopts)
-	ctx.SetFunc(goopts)
+	ctx.Funcs.Bind(goopts)
 	libs.SetIncludePaths(goopts, ctx.IncludePaths)
 	libs.SassOptionSetPrecision(goopts, ctx.Precision)
 	libs.SassOptionSetOutputStyle(goopts, ctx.OutputStyle)

--- a/context_test.go
+++ b/context_test.go
@@ -105,15 +105,12 @@ func TestLibsassError(t *testing.T) {
 
 	var out bytes.Buffer
 	ctx := NewContext()
-	if ctx.Cookies == nil {
-		ctx.Cookies = make([]Cookie, 1)
-	}
 
-	ctx.Cookies[0] = Cookie{
+	ctx.Funcs.Add(Func{
 		Sign: "foo()",
 		Fn:   TestCallback,
 		Ctx:  &ctx,
-	}
+	})
 	err := ctx.Compile(in, &out)
 
 	if err == nil {
@@ -143,10 +140,8 @@ func ExampleContext_Compile() {
 	var out bytes.Buffer
 	ctx := NewContext()
 	//Customs: []string{"foo()"},
-	if ctx.Cookies == nil {
-		ctx.Cookies = make([]Cookie, 1)
-	}
-	ctx.Cookies[0] = Cookie{
+
+	ctx.Funcs.Add(Func{
 		Sign: "foo()",
 		Fn: func(v interface{}, usv libs.UnionSassValue, rsv *libs.UnionSassValue) error {
 			res, _ := Marshal("no-repeat")
@@ -154,7 +149,7 @@ func ExampleContext_Compile() {
 			return nil
 		},
 		Ctx: &ctx,
-	}
+	})
 	err := ctx.Compile(in, &out)
 	if err != nil {
 		panic(err)

--- a/context_test.go
+++ b/context_test.go
@@ -34,7 +34,7 @@ p {
 }`)
 
 	var out bytes.Buffer
-	ctx := Context{}
+	ctx := NewContext()
 	err := ctx.Compile(in, &out)
 	if err != nil {
 		panic(err)
@@ -58,7 +58,7 @@ p {
 
 func TestContextNilRun(t *testing.T) {
 	var in, out bytes.Buffer
-	ctx := Context{}
+	ctx := NewContext()
 	err := ctx.Compile(&in, &out)
 	if err == nil {
 		t.Error("No error returned")
@@ -80,7 +80,7 @@ div {
 `)
 
 	var out bytes.Buffer
-	ctx := Context{}
+	ctx := NewContext()
 	err := ctx.Compile(in, &out)
 	if err != nil {
 		panic(err)
@@ -104,7 +104,7 @@ func TestLibsassError(t *testing.T) {
 }`)
 
 	var out bytes.Buffer
-	ctx := Context{}
+	ctx := NewContext()
 	if ctx.Cookies == nil {
 		ctx.Cookies = make([]Cookie, 1)
 	}
@@ -141,9 +141,8 @@ func ExampleContext_Compile() {
 			}`)
 
 	var out bytes.Buffer
-	ctx := Context{
+	ctx := NewContext()
 	//Customs: []string{"foo()"},
-	}
 	if ctx.Cookies == nil {
 		ctx.Cookies = make([]Cookie, 1)
 	}

--- a/error_test.go
+++ b/error_test.go
@@ -16,7 +16,7 @@ func TestError_basic(t *testing.T) {
   @include invalid-function('');
 }`)
 	out := bytes.NewBuffer([]byte(""))
-	ctx := Context{}
+	ctx := NewContext()
 	err := ctx.Compile(in, out)
 	if err == nil {
 		t.Error("No error returned")
@@ -41,7 +41,7 @@ func TestError_JSON(t *testing.T) {
 	in := bytes.NewBufferString(`div {
   height: 10px;`)
 	out := &bytes.Buffer{}
-	ctx := Context{}
+	ctx := NewContext()
 	err := ctx.Compile(in, out)
 
 	e := `Error > stdin:2
@@ -64,7 +64,7 @@ func TestError_unbound(t *testing.T) {
   background: map-get($sprite,139);
 }`)
 	out := bytes.NewBuffer([]byte(""))
-	ctx := Context{}
+	ctx := NewContext()
 	err := ctx.Compile(in, out)
 	if err == nil {
 		t.Error("No error returned")
@@ -86,7 +86,7 @@ div {
   background: uniqueFnName(randfile);
 }`)
 	out := bytes.NewBuffer([]byte(""))
-	ctx := Context{}
+	ctx := NewContext()
 	err := ctx.Compile(in, out)
 	if err == nil {
 		t.Error("No error returned")
@@ -113,7 +113,7 @@ func TestError_import(t *testing.T) {
 `)
 
 	out := bytes.NewBuffer([]byte(""))
-	ctx := Context{}
+	ctx := NewContext()
 	err := ctx.Compile(in, out)
 	if err == nil {
 		t.Error("No error returned")
@@ -137,7 +137,7 @@ func TestError_processsass(t *testing.T) {
   "column": 20,
   "message": "error in C function inline-image: format: .svg not supported\nBacktrace:\n\tstdin:3100, in function inline-image\n\tstdin:3100, in mixin printCSSImg\n\tstdin:3117"
 }`)
-	ctx := Context{}
+	ctx := NewContext()
 	err := ctx.ProcessSassError(in)
 	if err != nil {
 		t.Error(err)
@@ -155,7 +155,7 @@ Backtrace:
 }
 
 func TestError_invalid(t *testing.T) {
-	ctx := Context{}
+	ctx := NewContext()
 	err := ctx.ProcessSassError([]byte("/a"))
 
 	if len(err.Error()) == 0 {
@@ -164,7 +164,7 @@ func TestError_invalid(t *testing.T) {
 }
 
 func TestError_line(t *testing.T) {
-	ctx := Context{}
+	ctx := NewContext()
 	ctx.errorString = "Error > stdin:1000"
 	if e := 1000; e != ctx.ErrorLine() {
 		t.Errorf("got: %d wanted: %d", ctx.ErrorLine(), e)

--- a/export_test.go
+++ b/export_test.go
@@ -6,15 +6,15 @@ import (
 )
 
 func TestRegisterHandler(t *testing.T) {
-	l := len(handlers)
+	l := len(globalHandlers)
 	RegisterHandler("foo",
 		func(v interface{}, csv SassValue, rsv *SassValue) error {
 			u, _ := Marshal(false)
 			*rsv = u
 			return nil
 		})
-	if e := l + 1; len(handlers) != e {
-		t.Errorf("got: %d wanted: %d", len(handlers), e)
+	if e := l + 1; len(globalHandlers) != e {
+		t.Errorf("got: %d wanted: %d", len(globalHandlers), e)
 	}
 }
 

--- a/file_test.go
+++ b/file_test.go
@@ -10,7 +10,7 @@ import (
 func TestFile_resolved(t *testing.T) {
 	path := "test/scss/main.scss"
 	var out bytes.Buffer
-	ctx := Context{}
+	ctx := NewContext()
 	err := ctx.FileCompile(path, &out)
 	if err != nil {
 		panic(err)

--- a/func.go
+++ b/func.go
@@ -1,6 +1,26 @@
 package libsass
 
-import "github.com/wellington/go-libsass/libs"
+import (
+	"sync"
+
+	"github.com/wellington/go-libsass/libs"
+)
+
+var ghMu sync.RWMutex
+
+// globalHandlers is the list of predefined handlers registered externally
+var globalHandlers []handler
+
+// RegisterHandler sets the passed signature and callback to the
+// handlers array.
+func RegisterHandler(sign string, callback HandlerFunc) {
+	ghMu.Lock()
+	globalHandlers = append(globalHandlers, handler{
+		sign:     sign,
+		callback: Handler(callback),
+	})
+	ghMu.Unlock()
+}
 
 // HandlerFunc describes the method signature for registering
 // a Go function to be called by libsass.
@@ -20,7 +40,9 @@ func Handler(h HandlerFunc) libs.SassCallback {
 
 		// FIXME: This shouldn't be happening, handler should assign
 		// to the address properly.
-		*rsv = res.Val()
+		if rsv != nil {
+			*rsv = res.Val()
+		}
 
 		return err
 	}
@@ -29,15 +51,6 @@ func Handler(h HandlerFunc) libs.SassCallback {
 type handler struct {
 	sign     string
 	callback libs.SassCallback
-}
-
-// RegisterHandler sets the passed signature and callback to the
-// handlers array.
-func RegisterHandler(sign string, callback HandlerFunc) {
-	handlers = append(handlers, handler{
-		sign:     sign,
-		callback: Handler(callback),
-	})
 }
 
 var _ libs.SassCallback = TestCallback
@@ -54,35 +67,61 @@ var TestCallback = testCallback(func(_ interface{}, _ SassValue, _ *SassValue) e
 	return nil
 })
 
-// handlers is the list of registered sass handlers
-var handlers []handler
-
 // Cookie is used for passing context information to libsass.  Cookie is
 // passed to custom handlers when libsass executes them through the go
 // bridge.
-type Cookie struct {
+type Func struct {
 	Sign string
 	Fn   libs.SassCallback
 	Ctx  interface{}
 }
 
+type Funcs struct {
+	sync.RWMutex
+	wg      sync.WaitGroup
+	closing chan struct{}
+	f       []Func
+	idx     *string
+
+	// Func are complex, we need a reference to the entire context to
+	// successfully execute them.
+	ctx *Context
+}
+
+func NewFuncs(ctx *Context) *Funcs {
+	return &Funcs{
+		closing: make(chan struct{}),
+		ctx:     ctx,
+	}
+}
+
+func (fs *Funcs) Add(f Func) {
+	fs.Lock()
+	defer fs.Unlock()
+	fs.f = append(fs.f, f)
+}
+
 // SetFunc assigns the registered methods to SassOptions. Functions
 // are called when the compiler encounters the registered signature.
-func (ctx *Context) SetFunc(goopts libs.SassOptions) {
-	cookies := make([]libs.Cookie, len(handlers)+len(ctx.Cookies))
+func (fs *Funcs) Bind(goopts libs.SassOptions) {
+	ghMu.RLock()
+	cookies := make([]libs.Cookie, len(globalHandlers)+len(fs.f))
 	// Append registered handlers to cookie array
-	for i, h := range handlers {
+	for i, h := range globalHandlers {
 		cookies[i] = libs.Cookie{
 			Sign: h.sign,
 			Fn:   h.callback,
-			Ctx:  ctx,
+			Ctx:  fs.ctx,
 		}
 	}
-	for i, h := range ctx.Cookies {
-		cookies[i+len(handlers)] = libs.Cookie{
+	l := len(globalHandlers)
+	ghMu.RUnlock()
+
+	for i, h := range fs.f {
+		cookies[i+l] = libs.Cookie{
 			Sign: h.Sign,
 			Fn:   h.Fn,
-			Ctx:  ctx,
+			Ctx:  fs.ctx,
 		}
 	}
 	libs.BindFuncs(goopts, cookies)

--- a/func.go
+++ b/func.go
@@ -94,9 +94,9 @@ func (ctx *Context) SetFunc(goopts libs.SassOptions) {
 	// surprisingly enough
 	// disable garbage collection of cookies. These need to
 	// be manually freed in the wrapper
-	runtime.SetFinalizer(&cookies, nil)
-	ctx.cookies = &cookies
+	// runtime.SetFinalizer(&cookies, nil)
 	gofns := make([]libs.SassFunc, len(cookies))
+	runtime.SetFinalizer(&gofns, nil)
 	for i, cookie := range cookies {
 		fn := libs.SassMakeFunction(cookie.Sign,
 			unsafe.Pointer(&cookies[i]))

--- a/func.go
+++ b/func.go
@@ -1,6 +1,7 @@
 package libsass
 
 import (
+	"runtime"
 	"unsafe"
 
 	"github.com/wellington/go-libsass/libs"
@@ -93,6 +94,8 @@ func (ctx *Context) SetFunc(goopts libs.SassOptions) {
 	// surprisingly enough
 	// disable garbage collection of cookies. These need to
 	// be manually freed in the wrapper
+	runtime.SetFinalizer(&cookies, nil)
+	ctx.cookies = &cookies
 	gofns := make([]libs.SassFunc, len(cookies))
 	for i, cookie := range cookies {
 		fn := libs.SassMakeFunction(cookie.Sign,

--- a/func.go
+++ b/func.go
@@ -1,11 +1,6 @@
 package libsass
 
-import (
-	"runtime"
-	"unsafe"
-
-	"github.com/wellington/go-libsass/libs"
-)
+import "github.com/wellington/go-libsass/libs"
 
 // HandlerFunc describes the method signature for registering
 // a Go function to be called by libsass.
@@ -90,17 +85,5 @@ func (ctx *Context) SetFunc(goopts libs.SassOptions) {
 			Ctx:  ctx,
 		}
 	}
-	// TODO: this seems to run fine with garbage collection on
-	// surprisingly enough
-	// disable garbage collection of cookies. These need to
-	// be manually freed in the wrapper
-	// runtime.SetFinalizer(&cookies, nil)
-	gofns := make([]libs.SassFunc, len(cookies))
-	runtime.SetFinalizer(&gofns, nil)
-	for i, cookie := range cookies {
-		fn := libs.SassMakeFunction(cookie.Sign,
-			unsafe.Pointer(&cookies[i]))
-		gofns[i] = fn
-	}
-	libs.BindFuncs(goopts, gofns)
+	libs.BindFuncs(goopts, cookies)
 }

--- a/func.go
+++ b/func.go
@@ -1,6 +1,7 @@
 package libsass
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/wellington/go-libsass/libs"
@@ -81,7 +82,7 @@ type Funcs struct {
 	wg      sync.WaitGroup
 	closing chan struct{}
 	f       []Func
-	idx     *string
+	idx     []*string
 
 	// Func are complex, we need a reference to the entire context to
 	// successfully execute them.
@@ -124,5 +125,14 @@ func (fs *Funcs) Bind(goopts libs.SassOptions) {
 			Ctx:  fs.ctx,
 		}
 	}
-	libs.BindFuncs(goopts, cookies)
+	fs.idx = libs.BindFuncs(goopts, cookies)
+}
+
+func (fs *Funcs) Close() {
+	err := libs.RemoveFuncs(fs.idx)
+	if err != nil {
+		fmt.Println("error cleaning up funcs", err)
+	}
+	close(fs.closing)
+	fs.wg.Wait()
 }

--- a/func_test.go
+++ b/func_test.go
@@ -16,7 +16,7 @@ func TestFunc_simpletypes(t *testing.T) {
 }`)
 
 	//var out bytes.Buffer
-	ctx := Context{}
+	ctx := NewContext()
 	ctx.Cookies = make([]Cookie, 1)
 	// Communication channel for the C Sass callback function
 	ch := make(chan []interface{}, 1)
@@ -69,7 +69,7 @@ func TestFunc_colortype(t *testing.T) {
 }`)
 
 	//var out bytes.Buffer
-	ctx := Context{}
+	ctx := NewContext()
 	ctx.Cookies = make([]Cookie, 1)
 	// Communication channel for the C Sass callback function
 	ch := make(chan []interface{}, 1)
@@ -117,7 +117,7 @@ func TestFunc_complextypes(t *testing.T) {
 	   }`)
 
 	var out bytes.Buffer
-	ctx := Context{}
+	ctx := NewContext()
 	if ctx.Cookies == nil {
 		ctx.Cookies = make([]Cookie, 1)
 	}
@@ -163,7 +163,7 @@ func TestFunc_customarity(t *testing.T) {
 }`)
 
 	var out bytes.Buffer
-	ctx := Context{}
+	ctx := NewContext()
 	if ctx.Cookies == nil {
 		ctx.Cookies = make([]Cookie, 1)
 	}

--- a/func_test.go
+++ b/func_test.go
@@ -17,11 +17,10 @@ func TestFunc_simpletypes(t *testing.T) {
 
 	//var out bytes.Buffer
 	ctx := NewContext()
-	ctx.Cookies = make([]Cookie, 1)
 	// Communication channel for the C Sass callback function
 	ch := make(chan []interface{}, 1)
 
-	ctx.Cookies[0] = Cookie{
+	ctx.Funcs.Add(Func{
 
 		Sign: "foo($null, $num, $str, $bool)",
 		Fn: Handler(func(v interface{}, req SassValue, res *SassValue) error {
@@ -39,7 +38,7 @@ func TestFunc_simpletypes(t *testing.T) {
 			return nil
 		}),
 		Ctx: &ctx,
-	}
+	})
 	var out bytes.Buffer
 	err := ctx.Compile(in, &out)
 	if err != nil {
@@ -70,11 +69,10 @@ func TestFunc_colortype(t *testing.T) {
 
 	//var out bytes.Buffer
 	ctx := NewContext()
-	ctx.Cookies = make([]Cookie, 1)
 	// Communication channel for the C Sass callback function
 	ch := make(chan []interface{}, 1)
 
-	ctx.Cookies[0] = Cookie{
+	ctx.Funcs.Add(Func{
 		Sign: "foo($color)",
 		Fn: func(v interface{}, usv libs.UnionSassValue, rsv *libs.UnionSassValue) error {
 			// Send the interface fn arguments to the ch channel
@@ -89,7 +87,7 @@ func TestFunc_colortype(t *testing.T) {
 			return nil
 		},
 		Ctx: &ctx,
-	}
+	})
 	var out bytes.Buffer
 	err := ctx.Compile(in, &out)
 	if err != nil {
@@ -118,11 +116,8 @@ func TestFunc_complextypes(t *testing.T) {
 
 	var out bytes.Buffer
 	ctx := NewContext()
-	if ctx.Cookies == nil {
-		ctx.Cookies = make([]Cookie, 1)
-	}
 	ch := make(chan interface{}, 1)
-	ctx.Cookies[0] = Cookie{
+	ctx.Funcs.Add(Func{
 		Sign: "foo($list)",
 		Fn: func(v interface{}, usv libs.UnionSassValue, rsv *libs.UnionSassValue) error {
 			var sv interface{}
@@ -133,7 +128,7 @@ func TestFunc_complextypes(t *testing.T) {
 			return nil
 		},
 		Ctx: &ctx,
-	}
+	})
 	err := ctx.Compile(in, &out)
 	if err != nil {
 		t.Error(err)
@@ -164,15 +159,12 @@ func TestFunc_customarity(t *testing.T) {
 
 	var out bytes.Buffer
 	ctx := NewContext()
-	if ctx.Cookies == nil {
-		ctx.Cookies = make([]Cookie, 1)
-	}
 
-	ctx.Cookies[0] = Cookie{
+	ctx.Funcs.Add(Func{
 		Sign: "foo()",
 		Fn:   TestCallback,
 		Ctx:  &ctx,
-	}
+	})
 	err := ctx.Compile(in, &out)
 	if err == nil {
 		t.Error("No error thrown for incorrect arity")

--- a/header.go
+++ b/header.go
@@ -8,6 +8,13 @@ import (
 	"github.com/wellington/go-libsass/libs"
 )
 
+var globalHeaders []string
+
+// RegisterHeader fifo
+func RegisterHeader(body string) {
+	globalHeaders = append(globalHeaders, body)
+}
+
 type Header struct {
 	idx     *string
 	Content string
@@ -86,11 +93,4 @@ func (h *Headers) Has(s string) bool {
 
 func (h *Headers) Len() int {
 	return len(h.h)
-}
-
-var globalHeaders []string
-
-// RegisterHeader fifo
-func RegisterHeader(body string) {
-	globalHeaders = append(globalHeaders, body)
 }

--- a/header.go
+++ b/header.go
@@ -12,7 +12,9 @@ var globalHeaders []string
 
 // RegisterHeader fifo
 func RegisterHeader(body string) {
+	ghMu.Lock()
 	globalHeaders = append(globalHeaders, body)
+	ghMu.Unlock()
 }
 
 type Header struct {
@@ -40,11 +42,13 @@ func NewHeaders() *Headers {
 
 func (hdrs *Headers) Bind(opts libs.SassOptions) {
 	// Push the headers into the local array
+	ghMu.RLock()
 	for _, gh := range globalHeaders {
 		if !hdrs.Has(gh) {
 			hdrs.Add(gh)
 		}
 	}
+	ghMu.RUnlock()
 
 	// Loop through headers creating ImportEntry
 	entries := make([]libs.ImportEntry, hdrs.Len())

--- a/header.go
+++ b/header.go
@@ -1,7 +1,6 @@
 package libsass
 
 import (
-	"fmt"
 	"strconv"
 	"sync"
 
@@ -72,9 +71,7 @@ func (hdrs *Headers) Close() {
 	// Clean up memory reserved for headers
 	libs.RemoveHeaders(hdrs.idx)
 	close(hdrs.closing)
-	fmt.Println("waiting")
 	hdrs.wg.Wait()
-	fmt.Println("waited")
 }
 
 func (h *Headers) Add(s string) {

--- a/header.go
+++ b/header.go
@@ -9,11 +9,13 @@ import (
 
 func (ctx *Context) SetHeaders(opts libs.SassOptions) {
 	// Push the headers into the local array
+	ghmu.RLock()
 	for _, gh := range globalHeaders {
 		if !ctx.Headers.Has(gh) {
 			ctx.Headers.Add(gh)
 		}
 	}
+	ghmu.RUnlock()
 
 	// Loop through headers creating ImportEntry
 	entries := make([]libs.ImportEntry, ctx.Headers.Len())
@@ -61,9 +63,12 @@ func (h *Headers) Len() int {
 	return len(h.h)
 }
 
+var ghmu sync.RWMutex
 var globalHeaders []string
 
 // RegisterHeader fifo
 func RegisterHeader(body string) {
+	ghmu.Lock()
 	globalHeaders = append(globalHeaders, body)
+	ghmu.Unlock()
 }

--- a/header.go
+++ b/header.go
@@ -29,7 +29,8 @@ func (ctx *Context) SetHeaders(opts libs.SassOptions) {
 			SrcMap: "",
 		}
 	}
-	libs.BindHeader(opts, entries)
+	// ctx.entries = &entries
+	libs.BindHeader(opts, &entries)
 }
 
 type Header struct {

--- a/header.go
+++ b/header.go
@@ -1,25 +1,48 @@
 package libsass
 
 import (
+	"fmt"
 	"strconv"
 	"sync"
 
 	"github.com/wellington/go-libsass/libs"
 )
 
-func (ctx *Context) SetHeaders(opts libs.SassOptions) {
+type Header struct {
+	idx     *string
+	Content string
+}
+
+type Headers struct {
+	wg      sync.WaitGroup
+	closing chan struct{}
+	sync.RWMutex
+	h []Header
+	// idx is a pointer for libsass to lookup these Headers
+	idx *string
+}
+
+// NewHeaders instantiates a Headers for prefixing Sass to input
+// See: https://github.com/sass/libsass/wiki/API-Sass-Importer
+func NewHeaders() *Headers {
+	h := &Headers{
+		closing: make(chan struct{}),
+	}
+	return h
+}
+
+func (hdrs *Headers) Bind(opts libs.SassOptions) {
 	// Push the headers into the local array
-	ghmu.RLock()
 	for _, gh := range globalHeaders {
-		if !ctx.Headers.Has(gh) {
-			ctx.Headers.Add(gh)
+		if !hdrs.Has(gh) {
+			hdrs.Add(gh)
 		}
 	}
-	ghmu.RUnlock()
 
 	// Loop through headers creating ImportEntry
-	entries := make([]libs.ImportEntry, ctx.Headers.Len())
-	for i, ent := range ctx.Headers.h {
+	entries := make([]libs.ImportEntry, hdrs.Len())
+	hdrs.RLock()
+	for i, ent := range hdrs.h {
 		uniquename := "hdr" + strconv.FormatInt(int64(i), 10)
 		entries[i] = libs.ImportEntry{
 			// Each entry requires a unique identifier
@@ -29,17 +52,18 @@ func (ctx *Context) SetHeaders(opts libs.SassOptions) {
 			SrcMap: "",
 		}
 	}
-	// ctx.entries = &entries
-	libs.BindHeader(opts, entries)
+	hdrs.RUnlock()
+	// Preserve reference to libs address to these entries
+	hdrs.idx = libs.BindHeader(opts, entries)
 }
 
-type Header struct {
-	Content string
-}
-
-type Headers struct {
-	sync.RWMutex
-	h []Header
+func (hdrs *Headers) Close() {
+	// Clean up memory reserved for headers
+	libs.RemoveHeaders(hdrs.idx)
+	close(hdrs.closing)
+	fmt.Println("waiting")
+	hdrs.wg.Wait()
+	fmt.Println("waited")
 }
 
 func (h *Headers) Add(s string) {
@@ -64,12 +88,9 @@ func (h *Headers) Len() int {
 	return len(h.h)
 }
 
-var ghmu sync.RWMutex
 var globalHeaders []string
 
 // RegisterHeader fifo
 func RegisterHeader(body string) {
-	ghmu.Lock()
 	globalHeaders = append(globalHeaders, body)
-	ghmu.Unlock()
 }

--- a/header.go
+++ b/header.go
@@ -30,7 +30,7 @@ func (ctx *Context) SetHeaders(opts libs.SassOptions) {
 		}
 	}
 	// ctx.entries = &entries
-	libs.BindHeader(opts, &entries)
+	libs.BindHeader(opts, entries)
 }
 
 type Header struct {

--- a/header_test.go
+++ b/header_test.go
@@ -12,7 +12,7 @@ func TestSassHeader_single(t *testing.T) {
 `)
 
 	var out bytes.Buffer
-	ctx := Context{}
+	ctx := NewContext()
 	ctx.Headers.Add(`@mixin mix() {
   width: 50px;
 }
@@ -42,7 +42,7 @@ func TestSassHeader_multi(t *testing.T) {
 `)
 
 	var out bytes.Buffer
-	ctx := Context{}
+	ctx := NewContext()
 	ctx.Headers.Add(`@mixin mix() {
   width: 50px;
 }

--- a/importer.go
+++ b/importer.go
@@ -3,6 +3,7 @@ package libsass
 import (
 	"errors"
 	"io"
+	"runtime"
 	"sync"
 	"time"
 
@@ -107,5 +108,8 @@ func (ctx *Context) SetImporters(opts libs.SassOptions) {
 		}
 		i++
 	}
+	runtime.SetFinalizer(&entries, nil)
+	// set entries somewhere so GC doesn't collect it
+	ctx.entries = &entries
 	libs.BindImporter(opts, entries)
 }

--- a/importer.go
+++ b/importer.go
@@ -3,7 +3,6 @@ package libsass
 import (
 	"errors"
 	"io"
-	"runtime"
 	"sync"
 	"time"
 
@@ -108,8 +107,7 @@ func (ctx *Context) SetImporters(opts libs.SassOptions) {
 		}
 		i++
 	}
-	runtime.SetFinalizer(&entries, nil)
+
 	// set entries somewhere so GC doesn't collect it
-	ctx.entries = &entries
 	libs.BindImporter(opts, entries)
 }

--- a/importer.go
+++ b/importer.go
@@ -30,8 +30,22 @@ func (i Import) ModTime() time.Time {
 
 // Imports is a map with key of "path/to/file"
 type Imports struct {
+	wg      sync.WaitGroup
+	closing chan struct{}
 	sync.RWMutex
-	m map[string]Import
+	m   map[string]Import
+	idx *string
+}
+
+func NewImports() *Imports {
+	return &Imports{
+		closing: make(chan struct{}),
+	}
+}
+
+func (i *Imports) Close() {
+	close(i.closing)
+	i.wg.Wait()
 }
 
 // Init sets up a new Imports map
@@ -92,13 +106,14 @@ func (p *Imports) Len() int {
 	return len(p.m)
 }
 
-// SetImporters accepts a SassOptions and adds the registered
+// Bind accepts a SassOptions and adds the registered
 // importers in the context.
-func (ctx *Context) SetImporters(opts libs.SassOptions) {
-	entries := make([]libs.ImportEntry, ctx.Imports.Len())
+func (p *Imports) Bind(opts libs.SassOptions) {
+	entries := make([]libs.ImportEntry, p.Len())
 	i := 0
 
-	for _, ent := range ctx.Imports.m {
+	p.RLock()
+	for _, ent := range p.m {
 		bs := ent.bytes
 		entries[i] = libs.ImportEntry{
 			Parent: ent.Prev,
@@ -107,7 +122,8 @@ func (ctx *Context) SetImporters(opts libs.SassOptions) {
 		}
 		i++
 	}
+	p.RUnlock()
 
 	// set entries somewhere so GC doesn't collect it
-	libs.BindImporter(opts, entries)
+	p.idx = libs.BindImporter(opts, entries)
 }

--- a/importer_test.go
+++ b/importer_test.go
@@ -10,7 +10,7 @@ func TestSassImport_single(t *testing.T) {
 	in := bytes.NewBufferString(`@import "a";`)
 
 	var out bytes.Buffer
-	ctx := Context{}
+	ctx := NewContext()
 	ctx.Imports.m = make(map[string]Import)
 	ctx.Imports.Add("", "a", []byte("a { color: blue; }"))
 	err := ctx.Compile(in, &out)
@@ -29,7 +29,7 @@ func TestSassImport_single(t *testing.T) {
 func TestSassImport_file(t *testing.T) {
 
 	var out bytes.Buffer
-	ctx := Context{}
+	ctx := NewContext()
 	ctx.Imports.m = make(map[string]Import)
 	ctx.Imports.Add("test/scss/file.scss", "a", []byte("a { color: blue; }"))
 	err := ctx.FileCompile("test/scss/file.scss", &out)
@@ -51,7 +51,7 @@ func TestSassImport_multi(t *testing.T) {
 @import "b";`)
 
 	var out bytes.Buffer
-	ctx := Context{}
+	ctx := NewContext()
 	ctx.Imports.m = make(map[string]Import)
 	ctx.Imports.Add("", "a", []byte("a { color: blue; }"))
 	ctx.Imports.Add("", "b", []byte("b { font-weight: bold; }"))
@@ -79,7 +79,7 @@ div.branch {
 }`)
 
 	var out bytes.Buffer
-	ctx := Context{}
+	ctx := NewContext()
 	ctx.Imports.m = make(map[string]Import)
 	ctx.Imports.Add("", "branch", []byte(`%branch { color: brown; }`))
 	err := ctx.Compile(in, &out)
@@ -104,7 +104,7 @@ div.branch {
 }`)
 
 	var out bytes.Buffer
-	ctx := Context{}
+	ctx := NewContext()
 	ctx.Imports.m = make(map[string]Import)
 	ctx.Imports.Add("", "branch", []byte(`@import "leaf";
 %branch { color: brown; }`))
@@ -134,7 +134,7 @@ div.branch {
 }`)
 
 	var out bytes.Buffer
-	ctx := Context{}
+	ctx := NewContext()
 	ctx.Imports.m = make(map[string]Import)
 	err := ctx.Compile(in, &out)
 	if err == nil {
@@ -170,7 +170,7 @@ div.branch {
 }`)
 
 	var out bytes.Buffer
-	ctx := Context{}
+	ctx := NewContext()
 	ctx.Imports.m = make(map[string]Import)
 	ctx.Imports.Add("", "nope", []byte(`@import "leaf";
 %branch { color: brown; }`))

--- a/libs/export.go
+++ b/libs/export.go
@@ -4,6 +4,7 @@ package libs
 //
 import "C"
 import (
+	"fmt"
 	"sync"
 	"unsafe"
 )
@@ -29,10 +30,14 @@ var gobridgeMu sync.Mutex
 //
 //export GoBridge
 func GoBridge(cargs UnionSassValue, ptr unsafe.Pointer) UnionSassValue {
-	// gobridgeMu.Lock()
-	// defer gobridgeMu.Unlock()
 	// Recover the Cookie struct passed in
-	ck := *(*Cookie)(ptr)
+	idx := (*string)(ptr)
+	ck, ok := globalFuncs.get(idx).(Cookie)
+	if !ok {
+		fmt.Printf("failed to resolve Cookie %p\n", ptr)
+		return MakeNil()
+	}
+	// ck := *(*Cookie)(ptr)
 
 	var usv UnionSassValue
 	err := ck.Fn(ck.Ctx, cargs, &usv)

--- a/libs/export.go
+++ b/libs/export.go
@@ -3,7 +3,10 @@ package libs
 // #include "sass/context.h"
 //
 import "C"
-import "unsafe"
+import (
+	"sync"
+	"unsafe"
+)
 
 // SassCallback defines the callback libsass eventually executes in
 // sprite_sass
@@ -18,13 +21,19 @@ type Cookie struct {
 	Ctx  interface{}
 }
 
+// gate gobridge, it has some unknown race conditions
+var gobridgeMu sync.Mutex
+
 // GoBridge is exported to C for linking libsass to Go.  This function
 // adheres to the interface provided by libsass.
 //
 //export GoBridge
 func GoBridge(cargs UnionSassValue, ptr unsafe.Pointer) UnionSassValue {
+	// gobridgeMu.Lock()
+	// defer gobridgeMu.Unlock()
 	// Recover the Cookie struct passed in
 	ck := *(*Cookie)(ptr)
+
 	var usv UnionSassValue
 	err := ck.Fn(ck.Ctx, cargs, &usv)
 	_ = err

--- a/libs/func.go
+++ b/libs/func.go
@@ -28,9 +28,25 @@ func SassMakeFunction(signature string, ptr unsafe.Pointer) SassFunc {
 	return (SassFunc)(fn)
 }
 
+var globalFuncs SafeMap
+
+func init() {
+	globalFuncs.init()
+}
+
 // BindFuncs attaches a slice of Functions to a sass options. Signatures
 // are already defined in the SassFunc.
-func BindFuncs(opts SassOptions, funcs []SassFunc) {
+func BindFuncs(opts SassOptions, cookies []Cookie) {
+
+	funcs := make([]SassFunc, len(cookies))
+	for i, cookie := range cookies {
+		idx := globalFuncs.set(cookies[i])
+
+		fn := SassMakeFunction(cookie.Sign,
+			unsafe.Pointer(idx))
+		funcs[i] = fn
+	}
+
 	sz := C.size_t(len(funcs))
 	cfuncs := C.sass_make_function_list(sz)
 	for i, cfn := range funcs {

--- a/libs/func.go
+++ b/libs/func.go
@@ -36,15 +36,17 @@ func init() {
 
 // BindFuncs attaches a slice of Functions to a sass options. Signatures
 // are already defined in the SassFunc.
-func BindFuncs(opts SassOptions, cookies []Cookie) {
+func BindFuncs(opts SassOptions, cookies []Cookie) []*string {
 
 	funcs := make([]SassFunc, len(cookies))
+	ids := make([]*string, len(cookies))
 	for i, cookie := range cookies {
 		idx := globalFuncs.set(cookies[i])
 
 		fn := SassMakeFunction(cookie.Sign,
 			unsafe.Pointer(idx))
 		funcs[i] = fn
+		ids[i] = idx
 	}
 
 	sz := C.size_t(len(funcs))
@@ -53,4 +55,12 @@ func BindFuncs(opts SassOptions, cookies []Cookie) {
 		C.sass_function_set_list_entry(cfuncs, C.size_t(i), cfn)
 	}
 	C.sass_option_set_c_functions(opts, cfuncs)
+	return ids
+}
+
+func RemoveFuncs(ids []*string) error {
+	for _, idx := range ids {
+		delete(globalFuncs.m, idx)
+	}
+	return nil
 }

--- a/libs/func.go
+++ b/libs/func.go
@@ -24,6 +24,7 @@ func SassMakeFunction(signature string, ptr unsafe.Pointer) SassFunc {
 		csign,
 		C.Sass_Function_Fn(C.CallSassFunction),
 		ptr)
+
 	return (SassFunc)(fn)
 }
 

--- a/libs/header.go
+++ b/libs/header.go
@@ -21,10 +21,10 @@ import (
 )
 
 // This binds the header to the libsass header lookup
-func BindHeader(opts SassOptions, entries []ImportEntry) {
-	ptr := unsafe.Pointer(&entries)
+func BindHeader(opts SassOptions, entries *[]ImportEntry) {
+	ptr := unsafe.Pointer(entries)
 	// FIXME: this should be cleaned up manually later
-	runtime.SetFinalizer(&entries, nil)
+	runtime.SetFinalizer(entries, nil)
 	imper := C.sass_make_importer(
 		C.Sass_Importer_Fn(C.SassHeaders),
 		C.double(0),

--- a/libs/header.go
+++ b/libs/header.go
@@ -23,8 +23,9 @@ func init() {
 	globalHeaders.init()
 }
 
-// This binds the header to the libsass header lookup
-func BindHeader(opts SassOptions, entries []ImportEntry) {
+// BindHeader attaches the header to a libsass context ensuring
+// gc does not delete the pointers necessary to make this happen.
+func BindHeader(opts SassOptions, entries []ImportEntry) *string {
 
 	idx := globalHeaders.set(entries)
 	ptr := unsafe.Pointer(idx)
@@ -40,4 +41,10 @@ func BindHeader(opts SassOptions, entries []ImportEntry) {
 	C.sass_option_set_c_headers(
 		(*C.struct_Sass_Options)(unsafe.Pointer(opts)),
 		impers)
+	return idx
+}
+
+func RemoveHeaders(idx *string) error {
+	delete(globalHeaders.m, idx)
+	return nil
 }

--- a/libs/header.go
+++ b/libs/header.go
@@ -15,16 +15,20 @@ package libs
 // }
 //
 import "C"
-import (
-	"runtime"
-	"unsafe"
-)
+import "unsafe"
+
+var globalHeaders SafeMap
+
+func init() {
+	globalHeaders.init()
+}
 
 // This binds the header to the libsass header lookup
-func BindHeader(opts SassOptions, entries *[]ImportEntry) {
-	ptr := unsafe.Pointer(entries)
-	// FIXME: this should be cleaned up manually later
-	runtime.SetFinalizer(entries, nil)
+func BindHeader(opts SassOptions, entries []ImportEntry) {
+
+	idx := globalHeaders.set(entries)
+	ptr := unsafe.Pointer(idx)
+
 	imper := C.sass_make_importer(
 		C.Sass_Importer_Fn(C.SassHeaders),
 		C.double(0),

--- a/libs/importer.go
+++ b/libs/importer.go
@@ -35,14 +35,14 @@ import (
 // delete it
 type SafeMap struct {
 	sync.RWMutex
-	m map[string]interface{}
+	m map[*string]interface{}
 }
 
 func (s *SafeMap) init() {
-	s.m = make(map[string]interface{})
+	s.m = make(map[*string]interface{})
 }
 
-func (s *SafeMap) get(idx string) interface{} {
+func (s *SafeMap) get(idx *string) interface{} {
 	s.RLock()
 	defer s.RUnlock()
 	return s.m[idx]
@@ -58,16 +58,16 @@ func randString(n int) string {
 	return string(b)
 }
 
-func (s *SafeMap) delete(idx string) {
+func (s *SafeMap) delete(idx *string) {
 	s.Lock()
 	delete(s.m, idx)
 	s.Unlock()
 }
 
 // set accepts an entry and returns an index for it
-func (s *SafeMap) set(ie interface{}) string {
-	idx := randString(8)
-
+func (s *SafeMap) set(ie interface{}) *string {
+	i := randString(8)
+	idx := &i
 	s.Lock()
 	s.m[idx] = ie
 	defer s.Unlock()
@@ -85,7 +85,7 @@ func init() {
 func BindImporter(opts SassOptions, entries []ImportEntry) {
 
 	idx := globalImports.set(entries)
-	ptr := unsafe.Pointer(&idx)
+	ptr := unsafe.Pointer(idx)
 
 	imper := C.sass_make_importer(
 		C.Sass_Importer_Fn(C.SassImporterHandler),

--- a/libs/importer.go
+++ b/libs/importer.go
@@ -101,3 +101,8 @@ func BindImporter(opts SassOptions, entries []ImportEntry) *string {
 	)
 	return idx
 }
+
+func RemoveImporter(idx *string) error {
+	delete(globalImports.m, idx)
+	return nil
+}

--- a/libs/importer.go
+++ b/libs/importer.go
@@ -26,14 +26,66 @@ package libs
 // //size_t max_size = UINTMAX_MAX;
 import "C"
 import (
-	"runtime"
+	"math/rand"
+	"sync"
 	"unsafe"
 )
 
+// globalImports stores []ImportEntry in a place where GC won't
+// delete it
+type SafeMap struct {
+	sync.RWMutex
+	m map[string]interface{}
+}
+
+func (s *SafeMap) init() {
+	s.m = make(map[string]interface{})
+}
+
+func (s *SafeMap) get(idx string) interface{} {
+	s.RLock()
+	defer s.RUnlock()
+	return s.m[idx]
+}
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func randString(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return string(b)
+}
+
+func (s *SafeMap) delete(idx string) {
+	s.Lock()
+	delete(s.m, idx)
+	s.Unlock()
+}
+
+// set accepts an entry and returns an index for it
+func (s *SafeMap) set(ie interface{}) string {
+	idx := randString(8)
+
+	s.Lock()
+	s.m[idx] = ie
+	defer s.Unlock()
+
+	return idx
+}
+
+var globalImports SafeMap
+
+func init() {
+	globalImports.init()
+}
+
 // BindImporter attaches a custom importer Go function to an import in Sass
 func BindImporter(opts SassOptions, entries []ImportEntry) {
-	ptr := unsafe.Pointer(&entries)
-	runtime.SetFinalizer(&entries, nil)
+
+	idx := globalImports.set(entries)
+	ptr := unsafe.Pointer(&idx)
 
 	imper := C.sass_make_importer(
 		C.Sass_Importer_Fn(C.SassImporterHandler),

--- a/libs/importer.go
+++ b/libs/importer.go
@@ -82,7 +82,7 @@ func init() {
 }
 
 // BindImporter attaches a custom importer Go function to an import in Sass
-func BindImporter(opts SassOptions, entries []ImportEntry) {
+func BindImporter(opts SassOptions, entries []ImportEntry) *string {
 
 	idx := globalImports.set(entries)
 	ptr := unsafe.Pointer(idx)
@@ -99,4 +99,5 @@ func BindImporter(opts SassOptions, entries []ImportEntry) {
 		(*C.struct_Sass_Options)(unsafe.Pointer(opts)),
 		impers,
 	)
+	return idx
 }

--- a/libs/wrap.go
+++ b/libs/wrap.go
@@ -37,7 +37,12 @@ type ImportEntry struct {
 
 //export HeaderBridge
 func HeaderBridge(ptr unsafe.Pointer) C.Sass_Import_List {
-	entries := *(*[]ImportEntry)(ptr)
+	idx := (*string)(ptr)
+	entries, ok := globalHeaders.get(idx).([]ImportEntry)
+	if !ok {
+		fmt.Printf("failed to resolve header slice: %p\n", ptr)
+		return C.sass_make_import_list(C.size_t(1))
+	}
 
 	cents := C.sass_make_import_list(C.size_t(len(entries)))
 

--- a/libs/wrap.go
+++ b/libs/wrap.go
@@ -12,6 +12,7 @@ import "C"
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 	"unsafe"
@@ -75,7 +76,10 @@ func GetEntry(es []ImportEntry, parent string, path string) (string, error) {
 //
 //export ImporterBridge
 func ImporterBridge(url *C.char, prev *C.char, ptr unsafe.Pointer) C.Sass_Import_List {
-	entries := *(*[]ImportEntry)(ptr)
+	// Retrieve the index
+	fmt.Printf("iBridge: % #v\n", ptr)
+	idx := *(*string)(ptr)
+	entries := globalImports.get(idx).([]ImportEntry)
 
 	parent := C.GoString(prev)
 	rel := C.GoString(url)

--- a/libs/wrap.go
+++ b/libs/wrap.go
@@ -34,15 +34,6 @@ type ImportEntry struct {
 	SrcMap string
 }
 
-func GetEntry(es []ImportEntry, parent string, path string) (string, error) {
-	for _, e := range es {
-		if parent == e.Parent && path == e.Path {
-			return e.Source, nil
-		}
-	}
-	return "", errors.New("entry not found")
-}
-
 //export HeaderBridge
 func HeaderBridge(ptr unsafe.Pointer) C.Sass_Import_List {
 	entries := *(*[]ImportEntry)(ptr)
@@ -70,12 +61,22 @@ func HeaderBridge(ptr unsafe.Pointer) C.Sass_Import_List {
 	return cents
 }
 
+func GetEntry(es []ImportEntry, parent string, path string) (string, error) {
+	for _, e := range es {
+		if parent == e.Parent && path == e.Path {
+			return e.Source, nil
+		}
+	}
+	return "", errors.New("entry not found")
+}
+
 // ImporterBridge is called by C to pass Importer arguments into Go land. A
 // Sass_Import is returned for libsass to resolve.
 //
 //export ImporterBridge
 func ImporterBridge(url *C.char, prev *C.char, ptr unsafe.Pointer) C.Sass_Import_List {
 	entries := *(*[]ImportEntry)(ptr)
+
 	parent := C.GoString(prev)
 	rel := C.GoString(url)
 	list := C.sass_make_import_list(1)

--- a/libs/wrap.go
+++ b/libs/wrap.go
@@ -77,9 +77,12 @@ func GetEntry(es []ImportEntry, parent string, path string) (string, error) {
 //export ImporterBridge
 func ImporterBridge(url *C.char, prev *C.char, ptr unsafe.Pointer) C.Sass_Import_List {
 	// Retrieve the index
-	fmt.Printf("iBridge: % #v\n", ptr)
-	idx := *(*string)(ptr)
-	entries := globalImports.get(idx).([]ImportEntry)
+	idx := (*string)(ptr)
+	entries, ok := globalImports.get(idx).([]ImportEntry)
+	if !ok {
+		fmt.Printf("failed to resolve import slice: %p\n", ptr)
+		entries = []ImportEntry{}
+	}
 
 	parent := C.GoString(prev)
 	rel := C.GoString(url)

--- a/libs/wrap_dev.go
+++ b/libs/wrap_dev.go
@@ -2,6 +2,7 @@
 
 package libs
 
+// #cgo pkg-config: libsass
 // #cgo CPPFLAGS: -DUSE_LIBSASS
 // #cgo LDFLAGS: -lsass
 //

--- a/mixins.go
+++ b/mixins.go
@@ -1,7 +1,7 @@
 package libsass
 
 // Mixins registers the default list of supported mixins
-func Mixins(ctx *Context) {
+func init() {
 	RegisterHeader(`@mixin sprite-dimensions($map, $name) {
   $file: sprite-file($map, $name);
   height: image-height($file);

--- a/options_test.go
+++ b/options_test.go
@@ -10,9 +10,8 @@ func TestOption_precision(t *testing.T) {
 	in := bytes.NewBufferString(`a { height: (1/3)px; }`)
 
 	var out bytes.Buffer
-	ctx := Context{
-		Precision: 3,
-	}
+	ctx := NewContext()
+	ctx.Precision = 3
 	err := ctx.Compile(in, &out)
 	if err != nil {
 		t.Fatal(err)
@@ -27,9 +26,8 @@ func TestOption_precision(t *testing.T) {
 
 	in = bytes.NewBufferString(`a { height: (1/3)px; }`)
 	out.Reset()
-	ctx = Context{
-		Precision: 6,
-	}
+	ctx = NewContext()
+	ctx.Precision = 6
 	err = ctx.Compile(in, &out)
 	if err != nil {
 		t.Fatal(err)
@@ -48,9 +46,9 @@ func TestOption_style(t *testing.T) {
 	in := bytes.NewBufferString(`div { p { color: red; } }`)
 
 	var out bytes.Buffer
-	ctx := Context{
-		OutputStyle: 0,
-	}
+	ctx := NewContext()
+	ctx.OutputStyle = 0
+
 	err := ctx.Compile(in, &out)
 	if err != nil {
 		t.Fatal(err)
@@ -113,9 +111,9 @@ func TestOption_comment(t *testing.T) {
 	in := bytes.NewBufferString(`div { p { color: red; } }`)
 
 	var out bytes.Buffer
-	ctx := Context{
-		Comments: false,
-	}
+	ctx := NewContext()
+	ctx.Comments = false
+
 	err := ctx.Compile(in, &out)
 	if err != nil {
 		t.Fatal(err)
@@ -150,9 +148,8 @@ func TestOption_include(t *testing.T) {
 	in := bytes.NewBufferString(`@import "include";`)
 
 	var out bytes.Buffer
-	ctx := Context{
-		IncludePaths: []string{"test/scss"},
-	}
+	ctx := NewContext()
+	ctx.IncludePaths = []string{"test/scss"}
 	err := ctx.Compile(in, &out)
 	if err != nil {
 		t.Fatal(err)

--- a/test/scss/sprite.scss
+++ b/test/scss/sprite.scss
@@ -1,0 +1,7 @@
+$sprites: sprite-map("../img/*.png");
+$width: sprite-width($sprites, 139);
+div {
+    height: image-height(sprite-file($sprites, "139"));
+    width: image-width(sprite-file($sprites, "139"));
+	background: sprite($sprites, "139");
+}


### PR DESCRIPTION
big rewrite to support multithreaded operation

There were some minor internal refactors to make different systems Headers/Imports/Funcs handler their lifecycle.

The big change is managing pointers passed to C. There is no guarantee made that a pointer passed across the C barrier will be GC. We manually ensure these stick around with [SafeMap](https://github.com/wellington/go-libsass/blob/threadsafe/libs/importer.go#L36-L39). This keeps a reference to the string address that is passed across the C barrier. When this address is passed back to Go in callbacks, the SafeMap reference ensures that the address is not GC. Close() has been added to help clean up these references. This is a compromise as it still requires Go pointers be passed to C which may not be long for this world. https://github.com/golang/go/issues/8310