### PR TITLE
Add option for Imports

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -194,6 +194,13 @@ func BuildDir(path string) option {
 	}
 }
 
+func Importers(imports *Imports) option {
+	return func(c *sass) error {
+		c.ctx.Imports = imports
+		return nil
+	}
+}
+
 type option func(*sass) error
 
 func New(dst io.Writer, src io.Reader, opts ...option) (Compiler, error) {

--- a/compiler.go
+++ b/compiler.go
@@ -194,7 +194,8 @@ func BuildDir(path string) option {
 	}
 }
 
-func Importers(imports *Imports) option {
+// ImportsOption specifies configuration for import resolution
+func ImportsOption(imports *Imports) option {
 	return func(c *sass) error {
 		c.ctx.Imports = imports
 		return nil


### PR DESCRIPTION
Add the ability to configure the import resolution by allowing Imports overriding through options. Discussed in [issue 45](https://github.com/wellington/go-libsass/issues/45).