### PR TITLE
Remove unused init() in context_test.go

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -4,20 +4,10 @@ import (
 	"bytes"
 	"log"
 	"os"
-	"regexp"
 	"testing"
 
 	"github.com/wellington/go-libsass/libs"
 )
-
-var rerandom *regexp.Regexp
-
-func init() {
-	// Setup build directory
-	os.MkdirAll("test/build/img", 0755)
-	rerandom = regexp.MustCompile(`-\w{6}(?:\.(png|jpg))`)
-
-}
 
 func TestContextFile(t *testing.T) {
 


### PR DESCRIPTION
This is to deal with the following Lintian message when trying to package github.com/wellington/go-libsass for Debian:

```
I: golang-github-wellington-go-libsass-dev: package-contains-empty-directory usr/share/gocode/src/github.com/wellington/go-libsass/test/build/img/
N:
N:    This package installs an empty directory. This might be intentional but
N:    it's normally a mistake. If it is intentional, add a Lintian override.
```

But of course, I could be mistaken too.  ;-)  Please let me know!

Many thanks!