### PR TITLE
readme: add missing "go" marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To test
 
 Basic example more examples found in [examples](examples)
 
-```
+```go
 buf := bytes.NewBufferString("div { p { color: red; } }")
 if err != nil {
 	log.Fatal(err)


### PR DESCRIPTION
This enables proper syntax highlighting on GitHub.