### PR TITLE
Use correct function to unmarshal Sass Errors.

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -68,7 +68,12 @@ func unmarshal(arg SassValue, v interface{}) error {
 		return errors.New("Invalid SASS Value - Taylor Swift")
 	case reflect.String:
 		if libs.IsString(sv) || libs.IsError(sv) {
-			gc := libs.String(sv)
+			var gc string
+			if libs.IsString(sv) {
+				gc = libs.String(sv)
+			} else {
+				gc = libs.Error(sv)
+			}
 			//drop quotes
 			if t, err := strconv.Unquote(gc); err == nil {
 				gc = t

--- a/libs/encoding.go
+++ b/libs/encoding.go
@@ -181,6 +181,12 @@ func Len(usv UnionSassValue) int {
 	panic("call of len on unknown type")
 }
 
+func Error(usv UnionSassValue) string {
+	c := C.sass_error_get_message(usv)
+	gc := C.GoString(c)
+	return gc
+}
+
 func String(usv UnionSassValue) string {
 	c := C.sass_string_get_value(usv)
 	gc := C.GoString(c)


### PR DESCRIPTION
The location of the value in the Sass_Value union for Errors vs. Strings is different, so it can return bogus (usually NULL) values, depending on struct packing.

Fixes #71.