### PR TITLE
Remove extra indirection in SafeMap and callbacks.

### DIFF
--- a/libs/func.go
+++ b/libs/func.go
@@ -1,14 +1,15 @@
 package libs
 
+// #include <stdint.h>
 // #include <stdlib.h>
 // #include "sass/context.h"
 //
-// extern union Sass_Value* GoBridge( union Sass_Value* s_args, int idx);
+// extern union Sass_Value* GoBridge( union Sass_Value* s_args, uintptr_t idx);
 //
 // union Sass_Value* CallSassFunction( union Sass_Value* s_args, Sass_Function_Entry cb, struct Sass_Options* opts ) {
 //     void* cookie = sass_function_get_cookie(cb);
 //     union Sass_Value* ret;
-//     int idx = *((int *)cookie);
+//     uintptr_t idx = (uintptr_t)cookie;
 //     ret = GoBridge(s_args, idx);
 //     return ret;
 // }
@@ -19,9 +20,9 @@ import "unsafe"
 type SassFunc C.Sass_Function_Entry
 
 // SassMakeFunction binds a Go pointer to a Sass function signature
-func SassMakeFunction(signature string, idx *int) SassFunc {
+func SassMakeFunction(signature string, idx int) SassFunc {
 	csign := C.CString(signature)
-	ptr := unsafe.Pointer(idx)
+	ptr := unsafe.Pointer(uintptr(idx))
 	fn := C.sass_make_function(
 		csign,
 		C.Sass_Function_Fn(C.CallSassFunction),
@@ -46,7 +47,7 @@ func BindFuncs(opts SassOptions, cookies []Cookie) []int {
 		idx := globalFuncs.Set(cookies[i])
 		fn := SassMakeFunction(cookie.Sign, idx)
 		funcs[i] = fn
-		ids[i] = *idx
+		ids[i] = idx
 	}
 
 	sz := C.size_t(len(funcs))

--- a/libs/header.go
+++ b/libs/header.go
@@ -1,14 +1,15 @@
 package libs
 
+// #include <stdint.h>
 // #include <string.h>
 // #include "sass/context.h"
 //
-// extern struct Sass_Import** HeaderBridge(int idx);
+// extern struct Sass_Import** HeaderBridge(uintptr_t idx);
 //
 // Sass_Import_List SassHeaders(const char* cur_path, Sass_Importer_Entry cb, struct Sass_Compiler* comp)
 // {
 //   void* cookie = sass_importer_get_cookie(cb);
-//   int idx = *((int *)cookie);
+//   uintptr_t idx = (uintptr_t)cookie;
 //   Sass_Import_List list = HeaderBridge(idx);
 //   return list;
 //
@@ -33,7 +34,7 @@ func BindHeader(opts SassOptions, entries []ImportEntry) int {
 	imper := C.sass_make_importer(
 		C.Sass_Importer_Fn(C.SassHeaders),
 		czero,
-		unsafe.Pointer(idx),
+		unsafe.Pointer(uintptr(idx)),
 	)
 	impers := C.sass_make_importer_list(1)
 	C.sass_importer_set_list_entry(impers, 0, imper)
@@ -41,7 +42,7 @@ func BindHeader(opts SassOptions, entries []ImportEntry) int {
 	C.sass_option_set_c_headers(
 		(*C.struct_Sass_Options)(unsafe.Pointer(opts)),
 		impers)
-	return *idx
+	return idx
 }
 
 func RemoveHeaders(idx int) error {

--- a/libs/importer.go
+++ b/libs/importer.go
@@ -5,14 +5,14 @@ package libs
 // #include <string.h>
 // #include "sass/context.h"
 //
-// extern struct Sass_Import** ImporterBridge(const char* url, const char* prev, int idx);
+// extern struct Sass_Import** ImporterBridge(const char* url, const char* prev, uintptr_t idx);
 //
 // Sass_Import_List SassImporterHandler(const char* cur_path, Sass_Importer_Entry cb, struct Sass_Compiler* comp)
 // {
 //   void* cookie = sass_importer_get_cookie(cb);
 //   struct Sass_Import* previous = sass_compiler_get_last_import(comp);
 //   const char* prev_path = sass_import_get_imp_path(previous);
-//   int idx = *((int *) cookie);
+//   uintptr_t idx = (uintptr_t)cookie;
 //   Sass_Import_List list = ImporterBridge(cur_path, prev_path, idx);
 //   return list;
 // }
@@ -42,7 +42,7 @@ func init() {
 func BindImporter(opts SassOptions, resolver ImportResolver) int {
 
 	idx := globalImports.Set(resolver)
-	ptr := unsafe.Pointer(idx)
+	ptr := unsafe.Pointer(uintptr(idx))
 
 	imper := C.sass_make_importer(
 		C.Sass_Importer_Fn(C.SassImporterHandler),
@@ -56,7 +56,7 @@ func BindImporter(opts SassOptions, resolver ImportResolver) int {
 		(*C.struct_Sass_Options)(unsafe.Pointer(opts)),
 		impers,
 	)
-	return *idx
+	return idx
 }
 
 func RemoveImporter(idx int) error {

--- a/libs/safemap.go
+++ b/libs/safemap.go
@@ -7,12 +7,7 @@ import "sync"
 type SafeMap struct {
 	sync.RWMutex
 	idx int
-	m   map[int]gcmap
-}
-
-type gcmap struct {
-	idx *int
-	v   interface{}
+	m   map[int]interface{}
 }
 
 func (s *SafeMap) nextidx() int {
@@ -23,13 +18,13 @@ func (s *SafeMap) nextidx() int {
 }
 
 func (s *SafeMap) init() {
-	s.m = make(map[int]gcmap)
+	s.m = make(map[int]interface{})
 }
 
 func (s *SafeMap) Get(idx int) interface{} {
 	s.RLock()
 	defer s.RUnlock()
-	return s.m[idx].v
+	return s.m[idx]
 }
 
 func (s *SafeMap) Del(idx int) {
@@ -39,12 +34,11 @@ func (s *SafeMap) Del(idx int) {
 }
 
 // set accepts an entry and returns an index for it
-func (s *SafeMap) Set(ie interface{}) *int {
+func (s *SafeMap) Set(ie interface{}) int {
 	idx := s.nextidx()
-	pidx := &idx
 	s.Lock()
-	s.m[idx] = gcmap{pidx, ie}
+	s.m[idx] = ie
 	defer s.Unlock()
 
-	return pidx
+	return idx
 }

--- a/libs/wrap.go
+++ b/libs/wrap.go
@@ -1,7 +1,8 @@
 package libs
 
-// extern struct Sass_Import** HeaderBridge(int idx);
+// #include "stdint.h"
 //
+// extern struct Sass_Import** HeaderBridge(uintptr_t idx);
 //
 // #//for C.free
 // #include "stdlib.h"
@@ -36,7 +37,7 @@ type ImportEntry struct {
 }
 
 //export HeaderBridge
-func HeaderBridge(cint C.int) C.Sass_Import_List {
+func HeaderBridge(cint C.uintptr_t) C.Sass_Import_List {
 	idx := int(cint)
 	entries, ok := globalHeaders.Get(idx).([]ImportEntry)
 	if !ok {
@@ -80,7 +81,7 @@ func GetEntry(es []ImportEntry, parent string, path string) (string, error) {
 // Sass_Import is returned for libsass to resolve.
 //
 //export ImporterBridge
-func ImporterBridge(url *C.char, prev *C.char, cidx C.int) C.Sass_Import_List {
+func ImporterBridge(url *C.char, prev *C.char, cidx C.uintptr_t) C.Sass_Import_List {
 	var importResolver ImportResolver
 
 	// Retrieve the index


### PR DESCRIPTION
Sass doesn't actually care that the cookie is a real pointer, so just cast the number to a `uintptr_t` (which casts freely to a `void*`) and avoid the extra pointer and map.

Surprisingly, this fixes #73. I can only assume there is some race in creating the extra map, but I don't know for sure, as it doesn't manifest on other systems or with `-race` detection.