### PR TITLE
Add option to pass abs path of the previous module to a resolver

### DIFF
--- a/compiler_test.go
+++ b/compiler_test.go
@@ -2,8 +2,10 @@ package libsass
 
 import (
 	"bytes"
+	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -70,4 +72,123 @@ func TestCompiler_path(t *testing.T) {
 		t.Errorf("got: %d wanted: %d", len(comp.Imports()), e)
 	}
 
+}
+
+func TestCompiler_path_withpathsresolver(t *testing.T) {
+	var dst bytes.Buffer
+
+	absArgs := [][]string{}
+
+	comp, err := New(
+		&dst,
+		nil,
+		Path("test/scss/file.scss"),
+		ImportsOption(NewImportsWithResolver(func(importedUrl string, importerAbsPath string) (string, string, bool) {
+			absArgs = append(absArgs, []string{importedUrl, importerAbsPath})
+			if importedUrl == "a" {
+				return "test/scss/a.scss", ".a { color: #aaaaaa }\n@import 'b';", true
+			} else if importedUrl == "b" {
+				return "test/scss/b.scss", ".b { color: #bbbbbb }", true
+			}
+			return "", "", false
+		})),
+	)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = comp.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e := `.a {
+  color: #aaaaaa; }
+
+.b {
+  color: #bbbbbb; }
+`
+	if e != dst.String() {
+		t.Errorf("got: %s wanted: %s", dst.String(), e)
+	}
+
+	if e := 3; len(comp.Imports()) != e {
+		t.Errorf("got: %d wanted: %d", len(comp.Imports()), e)
+	}
+
+	expectedAbsArgs := `[[a test/scss/file.scss] [b a]]`
+	if absArgsStr := fmt.Sprintf("%+v", absArgs); expectedAbsArgs != absArgsStr {
+		t.Errorf("abs args got: %s wanted: %s", absArgsStr, expectedAbsArgs)
+	}
+}
+
+func TestCompiler_path_withabsresolver(t *testing.T) {
+	var dst bytes.Buffer
+
+	absArgs := [][]string{}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	comp, err := New(
+		&dst,
+		nil,
+		Path("test/scss/file.scss"),
+		ImportsOption(NewImportsWithAbsResolver(func(importedUrl string, importerAbsPath string) (string, string, bool) {
+			// convert the path to a stable representation
+			// (convert abs path to a relative path, with the prefix $CWD/)
+			var pathToSave string
+			if filepath.IsAbs(importerAbsPath) {
+				pathToSave, err = filepath.Rel(wd, importerAbsPath)
+				if err != nil {
+					t.Fatal(err)
+				}
+				pathToSave = "$CWD/" + pathToSave
+			} else {
+				pathToSave = importerAbsPath
+			}
+
+			// save the args
+			absArgs = append(absArgs, []string{
+				importedUrl,
+				filepath.ToSlash(pathToSave),
+			})
+
+			// handle magic modules "a" and "b"
+			if importedUrl == "a" {
+				return wd + filepath.FromSlash("/test/scss/a.scss"), ".a { color: #aaaaaa }\n@import 'b';", true
+			} else if importedUrl == "b" {
+				return wd + filepath.FromSlash("/test/scss/b.scss"), ".b { color: #bbbbbb }", true
+			}
+			return "", "", false
+		})),
+	)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = comp.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e := `.a {
+  color: #aaaaaa; }
+
+.b {
+  color: #bbbbbb; }
+`
+	if e != dst.String() {
+		t.Errorf("got: %s wanted: %s", dst.String(), e)
+	}
+
+	if e := 3; len(comp.Imports()) != e {
+		t.Errorf("got: %d wanted: %d", len(comp.Imports()), e)
+	}
+
+	expectedAbsArgs := `[[a $CWD/test/scss/file.scss] [b $CWD/test/scss/a.scss]]`
+	if absArgsStr := fmt.Sprintf("%+v", absArgs); expectedAbsArgs != absArgsStr {
+		t.Errorf("abs args got: %s wanted: %s", absArgsStr, expectedAbsArgs)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/wellington/go-libsass
+
+go 1.18
+
+require golang.org/x/net v0.0.0-20220921203646-d300de134e69

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/net v0.0.0-20220921203646-d300de134e69 h1:hUJpGDpnfwdJW8iNypFjmSY0sCBEL+spFTZ2eO+Sfps=
+golang.org/x/net v0.0.0-20220921203646-d300de134e69/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=


### PR DESCRIPTION
Hey, I implemented this for a project I'm working on and figured I'd PR it back in in case others could find it useful.

### Context

I'm reimplementing a node-sass style resolution algorithm, where a sass file may specify the file it wants to import with a `~`-prefixed node specifier. This resolves against the node_modules folders in the file tree.

However, if there are multiple versions of a library within a project, different imports of the same URL should resolve to different files on disc with different contents, so the resolver needs to know the path of the importer, not just the URL.

 For example:
```
node_modules/
├─ common-lib/
│  └─ util.scss
├─ component/
│  ├─ node_modules/
│  │  └─ common-lib/
│  │     └─ util.scss
│  └─ component.scss      @import '~common-lib/util.scss' should resolve to
│                           node_modules/component/node_modules/common-lib/util.scss
│
└─file.scss               @import '~common-lib/util.scss' should resolve to
                             node_modules/common-lib/util.scss
```

### Changes
- Adds a `ResolverMode` enum that changes the bridge function used when calling back into go to libs
- Adds a new api `NewImportsWithAbsResolver` that uses the abspath ResolverMode
- Adds go.mod and go.sum files:
  - `go build` and `go test` wouldn't work for me without a go.mod file
  - I couldn't reference the module locally with a `replace` directive without a go.mod file