### PR TITLE
Fix build with Go 1.20

### DIFF
--- a/libs/encoding.go
+++ b/libs/encoding.go
@@ -13,7 +13,7 @@ type UnionSassValue *C.union_Sass_Value
 
 // NewUnionSassValue creates a new empty UnionSassValue
 func NewUnionSassValue() UnionSassValue {
-	return &C.union_Sass_Value{}
+	return MakeNil()
 }
 
 func CloneValue(usv UnionSassValue) UnionSassValue {


### PR DESCRIPTION
The `union Sass_Value` is only forward declared in Sass headers, and no full definition is provided publicly. Go 1.20 now complains about instantiating incomplete types such as these:
```
libs/encoding.go:16:9: cgo.Incomplete can't be allocated in Go; it is incomplete (or unallocatable)
libs/encoding.go:247:26: cgo.Incomplete can't be allocated in Go; it is incomplete (or unallocatable)
```
Instead, create a NULL `Sass_Value`.