### PR TITLE
Fix sass on apple

### DIFF
--- a/blah/blah.go
+++ b/blah/blah.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/wellington/go-libsass/libs"
+	"github.com/tom-un/go-libsass/libs"
 )
 
 func main() {

--- a/context.go
+++ b/context.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/wellington/go-libsass/libs"
+	"github.com/tom-un/go-libsass/libs"
 )
 
 // Context handles the interactions with libsass.  Context

--- a/context_test.go
+++ b/context_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/wellington/go-libsass/libs"
+	"github.com/tom-un/go-libsass/libs"
 )
 
 func TestContextFile(t *testing.T) {

--- a/encoding.go
+++ b/encoding.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/wellington/go-libsass/libs"
+	"github.com/tom-un/go-libsass/libs"
 )
 
 var (

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/wellington/go-libsass/libs"
+	"github.com/tom-un/go-libsass/libs"
 )
 
 type unsupportedStruct struct {

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"os"
 
-	libsass "github.com/wellington/go-libsass"
+	libsass "github.com/tom-un/go-libsass"
 )
 
 func main() {

--- a/examples/customfunc/main.go
+++ b/examples/customfunc/main.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/wellington/go-libsass"
+	"github.com/tom-un/go-libsass"
 )
 
 // cryptotext is of type libsass.SassFunc. As libsass compiles the

--- a/examples/custompreamble/main.go
+++ b/examples/custompreamble/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/wellington/go-libsass"
+	"github.com/tom-un/go-libsass"
 )
 
 func main() {

--- a/examples/options/main.go
+++ b/examples/options/main.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"os"
 
-	libsass "github.com/wellington/go-libsass"
+	libsass "github.com/tom-un/go-libsass"
 )
 
 func main() {

--- a/export.go
+++ b/export.go
@@ -1,6 +1,6 @@
 package libsass
 
-import "github.com/wellington/go-libsass/libs"
+import "github.com/tom-un/go-libsass/libs"
 
 // Error takes a Go error and returns a libsass Error
 func Error(err error) SassValue {

--- a/func.go
+++ b/func.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/wellington/go-libsass/libs"
+	"github.com/tom-un/go-libsass/libs"
 )
 
 var ghMu sync.RWMutex

--- a/func_test.go
+++ b/func_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wellington/go-libsass/libs"
+	"github.com/tom-un/go-libsass/libs"
 )
 
 func TestFunc_simpletypes(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/wellington/go-libsass
+module github.com/tom-un/go-libsass
 
 go 1.18
 

--- a/header.go
+++ b/header.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/wellington/go-libsass/libs"
+	"github.com/tom-un/go-libsass/libs"
 )
 
 var globalHeaders []string

--- a/importer.go
+++ b/importer.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/wellington/go-libsass/libs"
+	"github.com/tom-un/go-libsass/libs"
 )
 
 var (

--- a/libsass-build/file.cpp
+++ b/libsass-build/file.cpp
@@ -430,37 +430,44 @@ namespace Sass {
         CloseHandle(hFile);
         // just convert from unsigned char*
         char* contents = (char*) pBuffer;
-      #else
+      #elif __APPLE__
+        // TODO: waiting for https://github.com/sass/libsass/pull/3183 to be merged.
+        // On OSX `fopen` can fail with "too many open files" but succeeds using `open`.
         struct stat st;
         if (stat(path.c_str(), &st) == -1 || S_ISDIR(st.st_mode)) return 0;
-        #ifdef __APPLE__
-          int file = open(path.c_str(), O_RDONLY);
-          char* contents = 0;
-          if (file != -1) {
-            size_t size = st.st_size;
-            // allocate an extra byte for the null char
-            // and another one for edge-cases in lexer
-            contents = (char*) malloc((size+2)*sizeof(char));
-            read(file, contents, size);
-            contents[size+0] = '\0';
-            contents[size+1] = '\0';
-            close(file);
-          }
-        #else
-          std::ifstream file(path.c_str(), std::ios::in | std::ios::binary | std::ios::ate);
-          char* contents = 0;
-          if (file.is_open()) {
-            size_t size = file.tellg();
-            // allocate an extra byte for the null char
-            // and another one for edge-cases in lexer
-            contents = (char*) malloc((size+2)*sizeof(char));
-            file.seekg(0, std::ios::beg);
-            file.read(contents, size);
-            contents[size+0] = '\0';
-            contents[size+1] = '\0';
-            file.close();
-          }
-        #endif
+        int file = open(path.c_str(), O_RDONLY);
+        char* contents = 0;
+        if (file != -1) {
+          size_t size = st.st_size;
+          contents = (char*) malloc((size+2)*sizeof(char));
+          read(file, contents, size);
+          contents[size+0] = '\0';
+          contents[size+1] = '\0';
+          close(file);
+        }
+      #else
+        // Read the file using `<cstdio>` instead of `<fstream>` for better portability.
+        // The `<fstream>` header initializes `<locale>` and this buggy in GCC4/5 with static linking.
+        // See:
+        // https://www.spinics.net/lists/gcchelp/msg46851.html
+        // https://github.com/sass/sassc-ruby/issues/128
+        struct stat st;
+        if (stat(path.c_str(), &st) == -1 || S_ISDIR(st.st_mode)) return 0;
+        FILE* fd = std::fopen(path.c_str(), "rb");
+        if (fd == nullptr) return nullptr;
+        const std::size_t size = st.st_size;
+        char* contents = static_cast<char*>(malloc(st.st_size + 2 * sizeof(char)));
+        if (std::fread(static_cast<void*>(contents), 1, size, fd) != size) {
+          free(contents);
+          std::fclose(fd);
+          return nullptr;
+        }
+        if (std::fclose(fd) != 0) {
+          free(contents);
+          return nullptr;
+        }
+        contents[size] = '\0';
+        contents[size + 1] = '\0';
       #endif
       std::string extension;
       if (path.length() > 5) {

--- a/toscss.go
+++ b/toscss.go
@@ -3,7 +3,7 @@ package libsass
 import (
 	"io"
 
-	"github.com/wellington/go-libsass/libs"
+	"github.com/tom-un/go-libsass/libs"
 )
 
 // ToScss converts Sass to Scss with libsass sass2scss.h

--- a/version.go
+++ b/version.go
@@ -1,6 +1,6 @@
 package libsass
 
-import "github.com/wellington/go-libsass/libs"
+import "github.com/tom-un/go-libsass/libs"
 
 // Version reports libsass version information
 func Version() string {


### PR DESCRIPTION
When using go-libsass on a Mac on OSX 14.1.1, it would fail with "File to import not found or unreadable: " errors.

The issue is in libsass in the `read_file` function in `file.cpp`.  On non-_WIN32 OS's it uses `std::ifstream` to read the file.  On OSX it always fails with `strerror(errno)` saying "Failure: too many open files".

On my system, `ulimit` and `ulimit -n` return the default "unlimited" / 256.  So I tried raising it in `/Library/LaunchDaemons/limit.maxfiles.plist` but it still didn't help.

I tried reverting the most recent change in `file.cpp` which used `fopen` instead of `std::ifstream`.  It still failed.

So, I tried using the Darwin `open`/`read` and it works!